### PR TITLE
test(db_endpoints): fixed test_convert_coordinates

### DIFF
--- a/test_database_endpoints.py
+++ b/test_database_endpoints.py
@@ -60,7 +60,7 @@ async def test_convert_coordinates():
             pprint(response.json())
             assert response.json() == {
                 "locations": [
-                    "University of the Philippines Alumni Engineers' Centennial Hall, P. Velasquez Street, Diliman, Quezon City, 1800 Metro Manila, Philippines",
+                    "J3X9+G94, P. Velasquez Street, Diliman, Quezon City, 1800 Metro Manila, Philippines",
                     "41-B Mapagkawanggawa, Diliman, Lungsod Quezon, 1101 Kalakhang Maynila, Philippines"
                 ]
             }


### PR DESCRIPTION
Fixed smoke test for `test_convert_coordinates`. 
It was broken when i reconfigured `result_type` of `gmaps.reverse_geocode`.